### PR TITLE
Fix/235 add ytd

### DIFF
--- a/application/dataentry/serializers.py
+++ b/application/dataentry/serializers.py
@@ -81,7 +81,7 @@ class BorderStationSerializer(serializers.ModelSerializer):
         return obj.staff_set.all().count()
 
     def get_ytd_interceptions(self, obj):
-        return Interceptee.objects.filter(interception_record__irf_number__startswith=obj.station_code, interception_record__date_time_of_interception__year=datetime.date.today().year).count()
+        return Interceptee.objects.filter(interception_record__irf_number__startswith=obj.station_code, kind='v', interception_record__date_time_of_interception__year=datetime.date.today().year).count()
 
 
 class InterceptionRecordListSerializer(serializers.ModelSerializer):

--- a/application/portal/views.py
+++ b/application/portal/views.py
@@ -34,5 +34,5 @@ class TallyDaysView(APIView):
             foo.append(day_records)
             i += 1
         results['days'] = foo
-        results['ytd'] = Interceptee.objects.filter(interception_record__date_time_of_interception__year=today.year).count()
+        results['ytd'] = Interceptee.objects.filter(kind='v', interception_record__date_time_of_interception__year=today.year).count()
         return Response(results, status=status.HTTP_200_OK)

--- a/application/portal/views.py
+++ b/application/portal/views.py
@@ -34,5 +34,5 @@ class TallyDaysView(APIView):
             foo.append(day_records)
             i += 1
         results['days'] = foo
-        results['ytd'] = Interceptee.objects.filter(interception_record__date_time_of_interception__year=date.year).count()
+        results['ytd'] = Interceptee.objects.filter(interception_record__date_time_of_interception__year=today.year).count()
         return Response(results, status=status.HTTP_200_OK)


### PR DESCRIPTION
Connects to #226 

- YTD Interceptions should only count victims.
- Test for 'ytd' failed during first week of year because it was using date.year which is 6 days in the past by the time that it is called at the end of the loop.