### PR TITLE
Bugfix/264 mdf word wrap

### DIFF
--- a/application/budget/helpers.py
+++ b/application/budget/helpers.py
@@ -8,6 +8,7 @@ BudgetLineItem = namedtuple('budgetItem', ['name', 'value'])
 class BudgetTable:
     ROW_HEIGHT = 18
     TITLE_HEIGHT = 36
+    NAME_LENGTH = 29
 
     def __init__(self, title, items):
         self.title = title
@@ -22,9 +23,8 @@ class BudgetTable:
         # for helping calculate the height required to render the table
         # using points where 1 point = 1/72 of an inch
         # not the greatest but hopefully future devs will find a better way - AS
-        row_count = len(self.items)
-        rows_with_multiline_text = len([item for item in self.items if len(item.name) > 29])
-        return (row_count + rows_with_multiline_text + 1) * self.ROW_HEIGHT + self.TITLE_HEIGHT
+        row_count = sum([(len(item.name) // self.NAME_LENGTH) + 1 for item in self.items])
+        return (row_count + 1) * self.ROW_HEIGHT + self.TITLE_HEIGHT
 
 
 class MoneyDistributionFormHelper:

--- a/application/budget/helpers.py
+++ b/application/budget/helpers.py
@@ -21,7 +21,10 @@ class BudgetTable:
     def height_required(self):
         # for helping calculate the height required to render the table
         # using points where 1 point = 1/72 of an inch
-        return (len(self.items)+1) * self.ROW_HEIGHT + self.TITLE_HEIGHT
+        # not the greatest but hopefully future devs will find a better way - AS
+        row_count = len(self.items)
+        rows_with_multiline_text = len([item for item in self.items if len(item.name) > 29])
+        return (row_count + rows_with_multiline_text + 1) * self.ROW_HEIGHT + self.TITLE_HEIGHT
 
 
 class MoneyDistributionFormHelper:

--- a/application/budget/templates/budget/MoneyDistributionTemplateV2.rml
+++ b/application/budget/templates/budget/MoneyDistributionTemplateV2.rml
@@ -69,7 +69,7 @@ z3c.rml docs can be found on their github page: https://github.com/zopefoundatio
         <blockTable colWidths="70% 30%" style="budgetGrid">
             {% for item in section.items %}
             <tr>
-                <td>{{ item.name }}</td>
+                <td><para>{{ item.name }}</para></td>
                 <td>{{ item.value|intcomma }}</td>
             </tr>
             {% endfor %}

--- a/application/budget/tests/test_helpers.py
+++ b/application/budget/tests/test_helpers.py
@@ -19,6 +19,16 @@ class BudgetTableTests(TestCase):
 
         self.assertEqual(target.height_required, (len(items)+1)*BudgetTable.ROW_HEIGHT + BudgetTable.TITLE_HEIGHT)
 
+    def test_height_required_should_account_for_items_with_multiline_text(self):
+        items = [
+            BudgetLineItem("one", 1),
+            BudgetLineItem("two", 2),
+            BudgetLineItem("This is a very long line of text to make sure we calculate correctly", 30)
+        ]
+        target = BudgetTable("Table", items)
+
+        self.assertEqual(target.height_required, (len(items)+3)*BudgetTable.ROW_HEIGHT + BudgetTable.TITLE_HEIGHT)
+
 
 class MoneyDistributionFormHelperTests(TestCase):
 


### PR DESCRIPTION
Budget items with long names now wrap instead of overlapping money values

Connects to #264

