### PR TITLE
Remove authentication requirement from MDFView

### DIFF
--- a/application/budget/views/money_distribution_views.py
+++ b/application/budget/views/money_distribution_views.py
@@ -90,8 +90,6 @@ class MoneyDistribution(viewsets.ViewSet):
         
 
 class MDFExportViewSet(viewsets.GenericViewSet):
-    permission_classes = (IsAuthenticated, HasPermission)
-    permissions_required = ['permission_budget_view']
 
     def get_mdf_pdf(self, request, uuid):
         budget = BorderStationBudgetCalculation.objects.get(mdf_uuid=uuid)


### PR DESCRIPTION
Connects to #361 

Should we remove authentication requirement for both this and the export or split the single get into its own view?