### PR TITLE
paginating the intercept alert API

### DIFF
--- a/application/dataentry/serializers.py
+++ b/application/dataentry/serializers.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 
 from rest_framework import serializers
 
@@ -321,7 +322,11 @@ class IntercepteeSerializer(serializers.ModelSerializer):
         ]
     person = PersonSerializer()
     
+
 class InterceptionAlertSerializer(serializers.ModelSerializer):
     class Meta:
         model = InterceptionAlert
         fields = ['json']
+
+    def to_representation(self, obj):
+        return json.loads(obj.json)

--- a/application/dataentry/views/interception_alert.py
+++ b/application/dataentry/views/interception_alert.py
@@ -3,18 +3,14 @@ import json
 from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
-from rest_api.authentication import HasPermission
 
 from dataentry.models import InterceptionAlert
 from dataentry.serializers import InterceptionAlertSerializer
 
 class InterceptionAlertViewSet(viewsets.ModelViewSet):
-    queryset = InterceptionAlert.objects.all()
-    serial_class = InterceptionAlertSerializer
-    permission_classes = (IsAuthenticated, HasPermission)
-    permissions_required = []
+    serializer_class = InterceptionAlertSerializer
+    permission_classes = [IsAuthenticated]
     
-    def get_interception_alerts(self, request):
-        latest_id = request.GET.get('latest_id',0)
-        results = self.queryset.filter(id__gt=latest_id).order_by('id')
-        return Response([json.loads(alert.json) for alert in results])
+    def get_queryset(self):
+        latest_id = self.request.GET.get('latest_id',0)
+        return InterceptionAlert.objects.filter(id__gt=latest_id).order_by('id')

--- a/application/rest_api/urls.py
+++ b/application/rest_api/urls.py
@@ -66,5 +66,5 @@ urlpatterns = [
         url(r'^country/$', CountryViewSet.as_view(list), name='Country'),
         url(r'^country/(?P<pk>\d+)/$', CountryViewSet.as_view(detail), name='Countrydetail'),
         
-       url(r'^intercept-alerts/$', InterceptionAlertViewSet.as_view({'get':'get_interception_alerts'}), name='InterceptionAlert'), 
+       url(r'^intercept-alerts/$', InterceptionAlertViewSet.as_view({'get':'list'}), name='InterceptionAlert'), 
 ]


### PR DESCRIPTION
* overrode the to_representation instead of overriding the list route on the viewset
* overrode get_queryset to generalize that functionality and add pagination by default