### PR TITLE
enabling the django admin features that we've sort of stopped using

### DIFF
--- a/application/budget/admin.py
+++ b/application/budget/admin.py
@@ -1,0 +1,29 @@
+from django.contrib import admin
+from budget.models import BorderStationBudgetCalculation, OtherBudgetItemCost, StaffSalary
+
+
+class BorderStationBudgetCalculationAdminModel(admin.ModelAdmin):
+    model = BorderStationBudgetCalculation
+    search_fields = ['border_station', 'month_year', 'mdf_uuid']
+    list_display = ['border_station', 'month_year', 'mdf_uuid']
+
+
+class OtherBudgetItemCostAdminModel(admin.ModelAdmin):
+    model = OtherBudgetItemCost
+    search_fields = ['budget_item_parent', 'form_section', 'name', 'cost']
+    list_display = ['budget_item_parent', 'form_section', 'name', 'cost']
+
+
+class StaffSalaryAdminModel(admin.ModelAdmin):
+    model = StaffSalary
+    search_fields = ['budget_calc_sheet', 'salary', 'staff_person']
+    list_display = ['budget_calc_sheet', 'salary', 'staff_person']
+
+
+admin.site.register(BorderStationBudgetCalculation, BorderStationBudgetCalculationAdminModel)
+admin.site.register(OtherBudgetItemCost, OtherBudgetItemCostAdminModel)
+admin.site.register(StaffSalary, StaffSalaryAdminModel)
+
+
+
+

--- a/application/budget/models.py
+++ b/application/budget/models.py
@@ -251,6 +251,9 @@ class BorderStationBudgetCalculation(models.Model):
     def mdf_file_name(self):
         return '{}-{}-{}-MDF.pdf'.format(self.border_station.station_code, self.month_year.month, self.month_year.year)
 
+    def __str__(self):
+        return "{} - {}".format(self.border_station.station_name, self.month_year)
+
 
 class OtherBudgetItemCost(models.Model):
 

--- a/application/dataentry/admin.py
+++ b/application/dataentry/admin.py
@@ -1,5 +1,8 @@
 from django.contrib import admin
-from dataentry.models import InterceptionRecord, VictimInterview, Address1, Address2, BorderStation
+from dataentry.models import InterceptionRecord, VictimInterview, Address1, Address2, BorderStation, AliasGroup, Country, Person, InterceptionAlert, SiteSettings, Interceptee
+
+class SiteSettingsAdmin(admin.ModelAdmin):
+    model = SiteSettings
 
 
 class InterceptionRecordAdmin(admin.ModelAdmin):
@@ -37,3 +40,10 @@ admin.site.register(VictimInterview, VictimInterviewAdmin)
 admin.site.register(Address1, Address1Admin)
 admin.site.register(BorderStation, BorderStationAdmin)
 admin.site.register(Address2, Address2Admin)
+
+admin.site.register(AliasGroup)
+admin.site.register(Interceptee)
+admin.site.register(Country)
+admin.site.register(Person)
+admin.site.register(InterceptionAlert)
+admin.site.register(SiteSettings, SiteSettingsAdmin)

--- a/application/dataentry/models/border_station.py
+++ b/application/dataentry/models/border_station.py
@@ -11,3 +11,6 @@ class BorderStation(models.Model):
     longitude = models.FloatField(null=True)
     open = models.BooleanField(default=True)
     operating_country = models.ForeignKey(Country, models.SET_NULL, null=True, blank=True)
+
+    def __str__(self):
+        return self.station_name

--- a/application/dreamsuite/settings/base.py
+++ b/application/dreamsuite/settings/base.py
@@ -59,8 +59,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'django_extensions',
     'rest_framework.authtoken',
-    'django_filters',
-    'prettyjson'
+    'django_filters'
 ]
 
 

--- a/application/dreamsuite/settings/base.py
+++ b/application/dreamsuite/settings/base.py
@@ -59,7 +59,8 @@ INSTALLED_APPS = [
     'rest_framework',
     'django_extensions',
     'rest_framework.authtoken',
-    'django_filters'
+    'django_filters',
+    'prettyjson'
 ]
 
 

--- a/application/static_border_stations/admin.py
+++ b/application/static_border_stations/admin.py
@@ -1,0 +1,30 @@
+from django.contrib import admin
+from static_border_stations.models import Staff, CommitteeMember, Location
+
+
+class PersonAdminModel(admin.ModelAdmin):
+    search_fields = ['email', 'first_name', 'last_name']
+    list_display = ['email', 'first_name', 'last_name']
+
+
+class StaffAdmin(PersonAdminModel):
+    model = Staff
+
+
+class LocationAdmin(admin.ModelAdmin):
+    search_fields = ['border_station', 'name', 'latitude', 'longitude', ]
+    list_display = ['border_station', 'name', 'latitude', 'longitude', ]
+    model = Location
+
+
+class CommitteeMemberAdmin(PersonAdminModel):
+    model = CommitteeMember
+
+
+admin.site.register(Staff, StaffAdmin)
+admin.site.register(CommitteeMember, CommitteeMemberAdmin)
+admin.site.register(Location, LocationAdmin)
+
+
+
+

--- a/application/static_border_stations/models.py
+++ b/application/static_border_stations/models.py
@@ -35,6 +35,8 @@ class Person(models.Model):
     def full_name(self):
         return self.first_name + ' ' + self.last_name
 
+    def __str__(self):
+        return self.full_name
 
 class Staff(Person):
     class Meta:

--- a/build/nginx/local.conf.template
+++ b/build/nginx/local.conf.template
@@ -27,7 +27,7 @@ server {
         alias /data/dist/;
     }
 
-    location ~ ^/(data-entry|api|login|logout|interceptee_fuzzy_matching)/ {
+    location ~ ^/(data-entry|api|login|logout|interceptee_fuzzy_matching|admin)/ {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $http_host;
         proxy_redirect off;

--- a/build/nginx/server.conf.template
+++ b/build/nginx/server.conf.template
@@ -63,7 +63,7 @@ server {
         alias /robots.txt;
     }
 
-	location ~ ^/(data-entry|api|login|logout|interceptee_fuzzy_matching)/ {
+	location ~ ^/(data-entry|api|login|logout|interceptee_fuzzy_matching|admin)/ {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
This will allow us to manage our data more easily for things like Red Flag text or Site Settings (fuzzy matching thresholds, etc.) by logging into a page rather than having to ssh into the server. 

The page is accessible at /admin/