### PR TITLE
feature - add creation date to alert response

### DIFF
--- a/application/dataentry/alert_checkers.py
+++ b/application/dataentry/alert_checkers.py
@@ -303,15 +303,10 @@ class IRFAlertChecker(object):
                 intercept['age'] = interceptee.person.age                
                 alert_dict['intercept'] = intercept
                 
-                # initial save to get the id initialized
                 interception_alert = InterceptionAlert()
-                interception_alert.json = '{}'
-                interception_alert.save()
-                alert_dict['id'] = interception_alert.id
-                
                 interception_alert.json = json.dumps(alert_dict)
-                logger.debug('json=' + interception_alert.json)
                 interception_alert.save()
+                logger.debug('json=' + interception_alert.json)
     
     def get_red_flags(self):
         logger.debug('get_red_flags')

--- a/application/dataentry/serializers.py
+++ b/application/dataentry/serializers.py
@@ -329,4 +329,7 @@ class InterceptionAlertSerializer(serializers.ModelSerializer):
         fields = ['json']
 
     def to_representation(self, obj):
-        return json.loads(obj.json)
+        alert_response = json.loads(obj.json)
+        alert_response['id'] = obj.id
+        alert_response['datetimeOfAlert'] = obj.created
+        return alert_response


### PR DESCRIPTION
I changed the process to use the serializer to inject the id and the created date of the alert into the response. This has the added benefit of not having to save the alert twice in the alert creation process as well