### PR TITLE
Update google_sheet_basic to force integer divide

### DIFF
--- a/application/export_import/google_sheet_basic.py
+++ b/application/export_import/google_sheet_basic.py
@@ -144,7 +144,7 @@ class GoogleSheetBasic:
     def convert_notation(self, row_index, column_index):
         notation = ''
         if column_index >= 26:
-            notation += chr(column_index / 26 + 64)
+            notation += chr(column_index // 26 + 64)
         notation += chr(column_index % 26 + 65)
         if row_index is not None:
             notation += str(row_index)


### PR DESCRIPTION
Connects to #402

Changes included:
* With python 2, division operator '/' of two integers results in an integer.  With python 3, that operator returns a float.  Update to use operator '//' for force an integer result.
*
*
