### PR TITLE
Fix incorrect mapping to old permission name for VIF-DELETE permission

### DIFF
--- a/application/dataentry/migrations/0058_edit_delete_permission.py
+++ b/application/dataentry/migrations/0058_edit_delete_permission.py
@@ -1,0 +1,12 @@
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('dataentry', '0057_auto_20180730_1616'),
+    ]
+    
+    operations = [
+       migrations.RunSQL("UPDATE dataentry_permission SET account_permission_name = 'permission_vif_delete' where permission_group = 'VIF' and action='DELETE';"),
+    ]


### PR DESCRIPTION
Connects to #425

Changes included:
*Add migration to correct permission name for VIF-DELETE
*
*
