### PR TITLE
Update VdfCore class to permit VDF exports to be audited.

### DIFF
--- a/application/dataentry/models/vdf_core.py
+++ b/application/dataentry/models/vdf_core.py
@@ -72,6 +72,10 @@ class VdfCore(BaseForm):
     
     def get_form_type_name(self):
         return 'VDF'
+    
+    @staticmethod
+    def key_field_name():
+        return 'vdf_number'
 
 class VdfAttachment(BaseCard):
     attachment_number = models.PositiveIntegerField(null=True, blank=True)


### PR DESCRIPTION
The VdfCore class was missing the static method key_field_name().  This method is required for the auditing of Google Sheet exports.

Connects to #

Changes included:
*
*
*
