### PR TITLE
Move api to retrieve google map key into a new view class.

### DIFF
--- a/application/dataentry/views/site_settings.py
+++ b/application/dataentry/views/site_settings.py
@@ -17,6 +17,9 @@ class SiteSettingsViewSet(viewsets.ModelViewSet):
         site_settings = SiteSettings.objects.all()[0]
         return Response(SiteSettingsSerializer(site_settings).data)
     
+class GoogleMapKeyViewSet(viewsets.ViewSet):
+    permission_classes = (IsAuthenticated,)
+    
     def retrieve_google_map_key(self, request):
         key_file = os.environ['GOOGLE_MAP_KEY']
         try:

--- a/application/rest_api/urls.py
+++ b/application/rest_api/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import url
 
 from dataentry.views import Address2ViewSet, Address1ViewSet, GeoCodeAddress1APIView, GeoCodeAddress2APIView, InterceptionRecordViewSet, VictimInterviewViewSet, IntercepteeViewSet, VictimInterviewDetailViewSet, PhotoExporter, IrfCsvExportView, VifCsvExportView, InterceptionAlertViewSet, PermissionViewSet, UserLocationPermissionViewSet
 from dataentry.views import PersonViewSet
-from dataentry.views import SiteSettingsViewSet
+from dataentry.views import SiteSettingsViewSet, GoogleMapKeyViewSet
 from dataentry.views import CountryViewSet
 from dataentry.views import IDManagementViewSet, TraffickerCheckViewSet, IrfFormViewSet, CifFormViewSet, VdfFormViewSet
 from dataentry.views import FormViewSet, FormTypeViewSet
@@ -40,7 +40,7 @@ urlpatterns = [
         #SiteSettings
         url(r'^site-settings/$', SiteSettingsViewSet.as_view({'get': 'retrieve_custom'}), name="SiteSettings"),
         url(r'^site-settings/(?P<pk>\d+)/$', SiteSettingsViewSet.as_view({'put': 'update'}), name="SiteSettingsUpdate"),
-        url(r'^site-settings/google_map_key/$', SiteSettingsViewSet.as_view({'get': 'retrieve_google_map_key'}), name="SiteSettings"),
+        url(r'^site-settings/google_map_key/$', GoogleMapKeyViewSet.as_view({'get': 'retrieve_google_map_key'}), name="GoogleMapKey"),
 
         # VIFs
         url(r'^vif/$', VictimInterviewViewSet.as_view(list), name="VictimInterview"),


### PR DESCRIPTION
The SiteSettingsViewSet was defined as requiring SuperAdministrator permissions, but those permissions should not be required to retrieve the google map key.

Connects to #

Changes included:
*
*
*
