### PR TITLE
Fix issue with duplicate LocationData records.

### DIFF
--- a/application/dataentry/views/statistics_dashboard.py
+++ b/application/dataentry/views/statistics_dashboard.py
@@ -333,13 +333,16 @@ class StationStatisticsViewSet(viewsets.ModelViewSet):
         current_locations = []
         for result in results:
             current_locations.append(result.location)
-        staff_entries = LocationStaff.objects.filter(location__border_station__id=station_id, year_month=year_month).exclude(location__in=current_locations)
+        staff_entries = LocationStaff.objects.filter(location__border_station__id=station_id, year_month=year_month).exclude(location__in=current_locations).order_by('location')
         if len(staff_entries) > 0:
+            last_location = None
             for entry in staff_entries:
-                location_statistics = LocationStatistics()
-                location_statistics.location = entry.location
-                location_statistics.year_month = entry.year_month
-                location_statistics.save()
+                if entry.location != last_location:
+                    last_location = entry.location
+                    location_statistics = LocationStatistics()
+                    location_statistics.location = entry.location
+                    location_statistics.year_month = entry.year_month
+                    location_statistics.save()
             results = LocationStatistics.objects.filter(location__border_station__id=station_id, year_month=year_month)
             
         serializer = LocationStatisticsSerializer(results, many=True, context={'request':request})


### PR DESCRIPTION
Connects to #936 

Changes included:
*
*
*
All of the duplicates have null values for the intercepts and arrests counts.  Removing all the dataentry_location_statistics rows that have null values for these two columns will remove all of the duplicates.  Note that this may remove additional rows that are not duplicates, but that will not cause any issue since no data will be lost..  Execute the following SQL command to remove the rows:
    delete from dataentry_locationstatistics where intercepts is null and arrests is null;