### PR TITLE
Fix legal case attachment number

### DIFF
--- a/application/fixtures/initial-required-data/form_data_LEGAL_CASE.json
+++ b/application/fixtures/initial-required-data/form_data_LEGAL_CASE.json
@@ -1330,7 +1330,9 @@
       "question": "lcAttachmentNumber",
       "category": "legalAttachment",
       "weight": 0,
-      "form_config": null
+      "form_config": {
+         "IndexQuestion": "lcAttachmentNumber"
+      }
    }
 },
 {


### PR DESCRIPTION
Connects to #

Changes included:
* Attachment number needed to be in form-data
*
*
